### PR TITLE
Move fallback ref-id from builder to client

### DIFF
--- a/src/neo4clj/convert.clj
+++ b/src/neo4clj/convert.clj
@@ -34,6 +34,10 @@
   "Converts a Neo4J internal entity to a Clojure Hash-Map"
   class)
 
+(defmethod neo4j->clj nil
+  [entity]
+  nil)
+
 (defmethod neo4j->clj Node
   [^Node node]
   (assoc (neo4j-entity-basics->clj node)

--- a/src/neo4clj/convert.clj
+++ b/src/neo4clj/convert.clj
@@ -57,7 +57,9 @@
        (map #(reduce (fn [m [k v]] (assoc m k (neo4j->clj v))) {} %))))
 
 (defn clj-value->neo4j-value
-  "Convert a given clojure primitive into its bolt query equivalent"
+  "Convert a given clojure primitive into its bolt query equivalent
+  If given a vector or list, all elements within needs to be of the same type.
+  This is a limitation in Neo4j not Neo4clj"
   [value]
   (cond
     (string? value) (str "'" value "'")
@@ -65,6 +67,7 @@
     (nil? value) "NULL"
     (boolean? value) (str/upper-case value)
     (keyword? value) (str "'" (name value) "'")
+    (instance? clojure.lang.IPersistentStack value) (str "[" (str/join ", " (map clj-value->neo4j-value value)) "]")
     (instance? java.time.Instant value) (str "'" (t/format :iso-instant value) "'")
     :else value))
 

--- a/src/neo4clj/query_builder.clj
+++ b/src/neo4clj/query_builder.clj
@@ -5,8 +5,8 @@
 
 (defn create-node-query
   "Returns the bolt query to create a node based on the given node representation"
-  [{:keys [ref-id] :or {ref-id (cypher/gen-ref-id)} :as node} return?]
-  (str "CREATE " (cypher/node (assoc node :ref-id ref-id)) (when return? (str " RETURN " ref-id))))
+  [{:keys [ref-id] :as node} return?]
+  (str "CREATE " (cypher/node node) (when return? (str " RETURN " ref-id))))
 
 (defn lookup-query
   "Takes a lookup representation and generates a bolt query
@@ -38,16 +38,13 @@
 (defn create-relationship-query
   "Returns the bolt query to create a one directional relationship
   based on the given relationship representation"
-  [{:keys [ref-id from to] :or {ref-id (cypher/gen-ref-id)} :as rel} return?]
+  [{:keys [ref-id from to] :as rel} return?]
   (let [from-ref-id (or (:ref-id from) (cypher/gen-ref-id))
         to-ref-id (or (:ref-id to) (cypher/gen-ref-id))]
     (str (lookup-non-referred-node from-ref-id from)
          (lookup-non-referred-node to-ref-id to)
          "CREATE "
-         (cypher/relationship
-          (str "(" from-ref-id ")")
-          (str "(" to-ref-id ")")
-          (assoc rel :ref-id ref-id))
+         (cypher/relationship (str "(" from-ref-id ")") (str "(" to-ref-id ")") rel)
          (when return? (str " RETURN " ref-id)))))
 
 (defn create-graph-query

--- a/test/neo4clj/convert_test.clj
+++ b/test/neo4clj/convert_test.clj
@@ -47,6 +47,7 @@
       "Neo" "Neo"
       true true
       false false
+      ["test" "something"] ["test" "something"]
       (time/instant "2018-04-28T12:53:11Z") "2018-04-28T12:53:11Z")))
 
 (t/deftest neo4j-entity-basics->clj
@@ -75,6 +76,8 @@
       "'Neo'" "Neo"
       "TRUE" true
       "FALSE" false
+      "'key'" :key
+      "['test', 'something', 'else']" ["test" "something" "else"]
       "'2018-04-28T12:53:11Z'" (time/instant "2018-04-28T12:53:11Z"))))
 
 (t/deftest hash-map->properties


### PR DESCRIPTION
  - This has been changed to ensure correct handling of returned
    hash-maps

  - There have also been added ref-id to the returned hash-map to
    enable continous use of the hash-map representation in other calls
    to Neo4clj