### PR TITLE
Upgrade driver 4.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [clojure.java-time "0.3.2"]
                  [com.rpl/specter "1.1.2"]
                  [org.clojure/clojure "1.10.0"]
-                 [org.neo4j.driver/neo4j-java-driver "1.7.2"]]
+                 [org.neo4j.driver/neo4j-java-driver "4.0.1"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
                                   [criterium "0.4.4"]]
                    :source-paths ["dev"]}})

--- a/src/neo4clj/client.clj
+++ b/src/neo4clj/client.clj
@@ -3,7 +3,7 @@
             [neo4clj.cypher :as cypher]
             [neo4clj.java-interop :as java-interop]
             [neo4clj.query-builder :as builder])
-  (:import  [org.neo4j.driver.v1 Driver Session StatementRunner Transaction]))
+  (:import  [org.neo4j.driver Driver Session QueryRunner Transaction]))
 
 (defn connect
   "Connect through bolt to the given neo4j server
@@ -79,10 +79,10 @@
    (with-open [session (create-session conn)]
      (java-interop/execute session query params))))
 
-(defmethod execute! StatementRunner
-  ([^StatementRunner runner ^String query]
+(defmethod execute! QueryRunner
+  ([^QueryRunner runner ^String query]
    (java-interop/execute runner query))
-  ([^StatementRunner runner ^String query ^clojure.lang.IPersistentMap params]
+  ([^QueryRunner runner ^String query ^clojure.lang.IPersistentMap params]
    (java-interop/execute runner query params)))
 
 (defn create-index!

--- a/src/neo4clj/convert.clj
+++ b/src/neo4clj/convert.clj
@@ -3,12 +3,12 @@
             [com.rpl.specter :as specter :refer [MAP-VALS]]
             [neo4clj.sanitize :as sanitize]
             [java-time :as t])
-  (:import [org.neo4j.driver.v1 Values]
-           [org.neo4j.driver.v1.types Entity
-                                      Node
-                                      Relationship]
-           [org.neo4j.driver.v1 Record
-                                StatementResult]))
+  (:import [org.neo4j.driver Values]
+           [org.neo4j.driver.types Entity
+                                   Node
+                                   Relationship]
+           [org.neo4j.driver Record
+                             Result]))
 
 ;; Pattern used to recognize date-time values from Neo4J
 (def date-time-pattern #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
@@ -54,9 +54,13 @@
   [^String item]
   item)
 
-(defmethod neo4j->clj StatementResult
-  [^StatementResult result]
-  (->> (iterator-seq result)
+(defmethod neo4j->clj String
+  [^String item]
+  item)
+
+(defmethod neo4j->clj Result
+  [^Result result]
+  (->> (.list result)
        (map (fn [^Record r] (.asMap r)))
        (map #(reduce (fn [m [k v]] (assoc m k (neo4j->clj v))) {} %))))
 

--- a/src/neo4clj/convert.clj
+++ b/src/neo4clj/convert.clj
@@ -50,6 +50,10 @@
          :start-id (.startNodeId rel)
          :end-id (.endNodeId rel)))
 
+(defmethod neo4j->clj String
+  [^String item]
+  item)
+
 (defmethod neo4j->clj StatementResult
   [^StatementResult result]
   (->> (iterator-seq result)

--- a/test/neo4clj/convert_test.clj
+++ b/test/neo4clj/convert_test.clj
@@ -5,7 +5,7 @@
 
 (def neo4j-node
   "Mock object to represent a Neo4J Node"
-  (proxy [org.neo4j.driver.v1.types.Node] []
+  (proxy [org.neo4j.driver.types.Node] []
     (id [] 1)
     (labels [] ["Person"])
     (asMap [] {"firstName" "Neo"
@@ -13,7 +13,7 @@
 
 (def neo4j-relationship
   "Mock object to represent a Neo4J Relationship"
-  (proxy [org.neo4j.driver.v1.types.Relationship] []
+  (proxy [org.neo4j.driver.types.Relationship] []
     (id [] 4)
     (type [] "EMPLOYEE")
     (startNodeId [] 4)
@@ -23,16 +23,16 @@
 
 (def neo4j-record
   "Mock object to represent a Neo4J Record containing tow Nodes"
-  (proxy [org.neo4j.driver.v1.Record] []
+  (proxy [org.neo4j.driver.Record] []
     (asMap [] {"n" neo4j-node "r" neo4j-relationship})))
 
 (def statement-result
-  "Atom used for the iterator functionality of StatementResult below"
+  "Atom used for the iterator functionality of Result below"
   (atom nil))
 
 (def neo4j-statement-result
-  "Mock object to represent a Neo4J StatementResult"
-  (proxy [org.neo4j.driver.v1.StatementResult] []
+  "Mock object to represent a Neo4J Result"
+  (proxy [org.neo4j.driver.Result] []
     (hasNext [] (not (empty? @statement-result)))
     (next [] (let [v (first @statement-result)]
                (swap! statement-result pop)


### PR DESCRIPTION
Upgrades the JDBC driver to the latest version, `4.0.1`. There were a few name changes that are detailed in the commit message, as well as a change to async behavior regarding the `org.neo4j.driver.Result` interface.

Regarding testing, I do not quite understand how your testing is working and didn't want to make dramatic changes. I did manually test the changes with a real database, which led to the discovery of a missing method for `java.lang.String` within the context of the `org.neo4j.driver.Result` interface. Behavior is otherwise consistent with the old driver.