### PR TITLE
Avoid NullPointerException when Driver isn't provided

### DIFF
--- a/src/neo4clj/client.clj
+++ b/src/neo4clj/client.clj
@@ -31,6 +31,7 @@
 (defn create-session
   "Create a new session on the given Neo4J connection"
   (^Session [^Connection {:keys [driver database] :as conn}]
+   (assert (instance? Driver driver) "Neo4J driver not provided - check DB connection.")
    (if database
      (.session driver (SessionConfig/forDatabase database))
      (.session driver))))


### PR DESCRIPTION
This improves the experience dealing with errors from the library.

Old message:
```
; Execution error (NullPointerException) at neo4clj.client/create-session (client.clj:36).
; null
```

New message
```
; Execution error (AssertionError) at neo4clj.client/create-session (client.clj:34).
; Assert failed: Neo4J driver not provided - check DB connection.
```